### PR TITLE
Support Application-only authentication

### DIFF
--- a/DataModels/Oauth/AccessToken.cs
+++ b/DataModels/Oauth/AccessToken.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Twity.DataModels.Oauth
+{
+	[Serializable]
+	public class AccessToken
+	{
+		public string token_type;
+		public string access_token;
+	}
+}

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Inspired by [Let's Tweet In Unity](https://www.assetstore.unity3d.com/jp/#!/cont
 
 ## Usage
 
-### Initialize
-
+### Authentication
+if you have access_token and access_token_secret,
 ```C#
 public class EventHandler : MonoBehaviour {
   void Start () {
@@ -40,6 +40,24 @@ public class EventHandler : MonoBehaviour {
   }  
 }
 ```
+
+if you have only consumer_key and consumer_secret,
+```C#
+public class EventHandler : MonoBehaviour {
+  void Start () {
+    Twity.Oauth.consumerKey       = "...";
+    Twity.Oauth.consumerSecret    = "...";
+    
+    StartCoroutine(Twity.Client.GetOauth2BearerToken(Callback));
+  }
+
+  private void Callback(bool success) {
+    // you write some request with application-only authentication
+    // https://developer.twitter.com/en/docs/basics/authentication/overview/application-only
+	}
+}
+```
+
 ### REST API
 
 #### GET search/tweets

--- a/scripts/TwitterOauth.cs
+++ b/scripts/TwitterOauth.cs
@@ -15,6 +15,8 @@ namespace Twity
         public static string consumerSecret { get; set; }
         public static string accessToken { get; set; }
         public static string accessTokenSecret { get; set; }
+
+        public static string bearerToken {get; set;}
         #endregion
 
         #region Public Method

--- a/scripts/twitterRequest.cs
+++ b/scripts/twitterRequest.cs
@@ -148,7 +148,15 @@ namespace Twity
 
         private static IEnumerator SendRequest(UnityWebRequest request, SortedDictionary<string, string> parameters, string method, string requestURL, TwitterCallback callback)
         {
-            request.SetRequestHeader("Authorization", Oauth.GenerateHeaderWithAccessToken(parameters, method, requestURL));
+            if (Twity.Oauth.accessToken != null && Twity.Oauth.accessToken != "")
+            {
+                request.SetRequestHeader("Authorization", Oauth.GenerateHeaderWithAccessToken(parameters, method, requestURL));
+            }
+            else if (Twity.Oauth.bearerToken != null && Twity.Oauth.bearerToken != "")
+            {
+                request.SetRequestHeader("Authorization", "Bearer " + Oauth.bearerToken);
+            } 
+            
             #if UNITY_2017_1
                     yield return request.Send();
             #endif

--- a/scripts/twitterRequest.cs
+++ b/scripts/twitterRequest.cs
@@ -9,6 +9,7 @@ using UnityEngine.Networking;
 namespace Twity
 {
     public delegate void TwitterCallback(bool success, string response);
+    public delegate void TwitterAuthenticationCallback(bool success);
 
     public class Client
     {
@@ -107,7 +108,7 @@ namespace Twity
             }
         }
 
-        public static IEnumerator GetOauth2BearerToken(TwitterCallback callback)
+        public static IEnumerator GetOauth2BearerToken(TwitterAuthenticationCallback callback)
         {
             string url = "https://api.twitter.com/oauth2/token";
 
@@ -128,15 +129,16 @@ namespace Twity
                     yield return request.SendWebRequest();
             #endif
 
-            if (request.isNetworkError) callback(false, JsonHelper.ArrayToObject(request.error));
+            if (request.isNetworkError) callback(false);
 
             if (request.responseCode == 200 || request.responseCode == 201)
             {
-                callback(true, JsonHelper.ArrayToObject(request.downloadHandler.text));
+                Twity.Oauth.bearerToken = JsonUtility.FromJson<Twity.DataModels.Oauth.AccessToken>(request.downloadHandler.text).access_token;
+                callback(true);
             }
             else
             {
-                callback(false, JsonHelper.ArrayToObject(request.downloadHandler.text));
+                callback(false);
             }
             
         }

--- a/scripts/twitterRequest.cs
+++ b/scripts/twitterRequest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Text;
 using Twity.Helpers;
 using UnityEngine;
 using UnityEngine.Networking;
@@ -104,6 +105,40 @@ namespace Twity
                 yield return SendRequest(request, parameters, "POST", REQUEST_URL, callback);
 
             }
+        }
+
+        public static IEnumerator GetOauth2BearerToken(TwitterCallback callback)
+        {
+            string url = "https://api.twitter.com/oauth2/token";
+
+            string credential = Helper.UrlEncode(Oauth.consumerKey) + ":" + Helper.UrlEncode(Oauth.consumerSecret);
+            credential = Convert.ToBase64String(Encoding.UTF8.GetBytes(credential));
+
+            WWWForm form = new WWWForm();
+            form.AddField("grant_type", "client_credentials");
+
+            UnityWebRequest request = UnityWebRequest.Post(url, form);
+            request.SetRequestHeader("ContentType", "application/x-www-form-urlencoded;charset=UTF-8");
+            request.SetRequestHeader("Authorization", "Basic " + credential);
+
+            #if UNITY_2017_1
+                    yield return request.Send();
+            #endif
+            #if UNITY_2017_2_OR_NEWER
+                    yield return request.SendWebRequest();
+            #endif
+
+            if (request.isNetworkError) callback(false, JsonHelper.ArrayToObject(request.error));
+
+            if (request.responseCode == 200 || request.responseCode == 201)
+            {
+                callback(true, JsonHelper.ArrayToObject(request.downloadHandler.text));
+            }
+            else
+            {
+                callback(false, JsonHelper.ArrayToObject(request.downloadHandler.text));
+            }
+            
         }
         #endregion
 


### PR DESCRIPTION
Without access_token and access_token_secret, we can request user_timeline, search in tweets, user infomation, and so on.
https://developer.twitter.com/en/docs/basics/authentication/overview/application-only