### PR TITLE
Support PIN-Based authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ public class EventHandler : MonoBehaviour {
     if (!success) return;
     // you write some request with application-only authentication
     // https://developer.twitter.com/en/docs/basics/authentication/overview/application-only
-	}
+  }
 }
 ```
 
@@ -68,13 +68,15 @@ public class EventHandler : MonoBehaviour {
     Twity.Oauth.consumerKey       = "...";
     Twity.Oauth.consumerSecret    = "...";
     
-    StartCoroutine(Twity.Client.GenerateRequestToken(Callback, "callback URL of your app"));
+    StartCoroutine(Twity.Client.GenerateRequestToken(Callback));
   }
 
-  void Callback(bool success) {
+  void Callback(bool success, string response) {
     if (!success) return;
-    // hogehoge
-	}
+    // When request successes, response is the URL for oauth/authorize.
+    // you can display that URL to user so that they may use a web browser to access Twitter.
+    // https://developer.twitter.com/en/docs/basics/authentication/overview/pin-based-oauth
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Inspired by [Let's Tweet In Unity](https://www.assetstore.unity3d.com/jp/#!/cont
 ## Usage
 
 ### Authentication
-if you have access_token and access_token_secret,
+If you have access_token and access_token_secret,
 ```C#
 public class EventHandler : MonoBehaviour {
   void Start () {
@@ -42,7 +42,8 @@ public class EventHandler : MonoBehaviour {
 ```
 
 
-if you have only consumer_key and consumer_secret,
+You can use application-only authentication.
+https://developer.twitter.com/en/docs/basics/authentication/overview/application-only
 ```C#
 public class EventHandler : MonoBehaviour {
   void Start () {
@@ -55,27 +56,36 @@ public class EventHandler : MonoBehaviour {
   void Callback(bool success) {
     if (!success) return;
     // you write some request with application-only authentication
-    // https://developer.twitter.com/en/docs/basics/authentication/overview/application-only
   }
 }
 ```
 
 
-if you want request_token,
+You can use PIN-Based Oauth.
+https://developer.twitter.com/en/docs/basics/authentication/overview/pin-based-oauth
 ```C#
 public class EventHandler : MonoBehaviour {
   void Start () {
     Twity.Oauth.consumerKey       = "...";
     Twity.Oauth.consumerSecret    = "...";
     
-    StartCoroutine(Twity.Client.GenerateRequestToken(Callback));
+    StartCoroutine(Twity.Client.GenerateRequestToken(RequestTokenCallback));
   }
 
-  void Callback(bool success, string response) {
+  void RequestCallback(bool success) {
     if (!success) return;
-    // When request successes, response is the URL for oauth/authorize.
-    // you can display that URL to user so that they may use a web browser to access Twitter.
-    // https://developer.twitter.com/en/docs/basics/authentication/overview/pin-based-oauth
+    // When request successes, you can display `Twity.Oauth.authorizeURL` to user so that they may use a web browser to access Twitter.
+  }
+  
+  void GenerateAccessToken(string pin) {
+    // pin is numbers displayed on web browser when user complete authorization.
+    
+    StartCoroutine(Twity.Client.GenerateAccessToken(pin, AccessTokenCallback));
+  }
+  
+  void AccessTokenCallback(bool success) {
+    if (!success) return;
+    // When success, authorization is completed. You can make request to other endpoint.
   }
 }
 ```

--- a/Scripts/TwitterOauth.cs
+++ b/Scripts/TwitterOauth.cs
@@ -20,6 +20,7 @@ namespace Twity
 
         public static string requestToken {get; set;}
         public static string requestTokenSecret {get; set;}
+        public static string authorizeURL { get; set; }
         #endregion
 
         #region Public Method
@@ -45,12 +46,12 @@ namespace Twity
         {
             string oauth_token = "";
             string oauth_token_secret = "";
-            if (accessToken != null && accessToken != "") 
+            if (!string.IsNullOrEmpty(accessToken)) 
             {
                 oauth_token = accessToken;
                 oauth_token_secret = accessTokenSecret;
             }
-            else if (requestToken != null && requestToken != "")
+            else if (!string.IsNullOrEmpty(requestToken))
             {
                 oauth_token = requestToken;
                 oauth_token_secret = requestTokenSecret;

--- a/Scripts/TwitterOauth.cs
+++ b/Scripts/TwitterOauth.cs
@@ -43,8 +43,21 @@ namespace Twity
         #region HelperMethods
         private static string GenerateSignature(SortedDictionary<string, string> parameters, string requestMethod, string requestURL)
         {
+            string oauth_token = "";
+            string oauth_token_secret = "";
+            if (accessToken != null && accessToken != "") 
+            {
+                oauth_token = accessToken;
+                oauth_token_secret = accessTokenSecret;
+            }
+            else if (requestToken != null && requestToken != "")
+            {
+                oauth_token = requestToken;
+                oauth_token_secret = requestTokenSecret;
+            }
+            
             AddDefaultOauthParams(parameters, consumerKey);
-            if (accessToken != null && accessToken != "") parameters.Add("oauth_token", accessToken);
+            parameters.Add("oauth_token", oauth_token);
 
             StringBuilder paramString = new StringBuilder();
             foreach (KeyValuePair<string, string> param in parameters)
@@ -57,7 +70,7 @@ namespace Twity
             string requestHeader = Helper.UrlEncode(requestMethod) + "&" + Helper.UrlEncode(requestURL);
             string signatureData = requestHeader + "&" + Helper.UrlEncode(paramString.ToString());
 
-            string signatureKey = Helper.UrlEncode(consumerSecret) + "&" + Helper.UrlEncode(accessTokenSecret);
+            string signatureKey = Helper.UrlEncode(consumerSecret) + "&" + Helper.UrlEncode(oauth_token_secret);
             HMACSHA1 hmacsha1 = new HMACSHA1(Encoding.ASCII.GetBytes(signatureKey));
             byte[] signatureBytes = hmacsha1.ComputeHash(Encoding.ASCII.GetBytes(signatureData));
             return Convert.ToBase64String(signatureBytes);

--- a/Scripts/TwitterRequest.cs
+++ b/Scripts/TwitterRequest.cs
@@ -142,7 +142,7 @@ namespace Twity
             }
         }
 
-        public static IEnumerator GenerateRequestToken(TwitterCallback callback)
+        public static IEnumerator GenerateRequestToken(TwitterAuthenticationCallback callback)
         {
             string url = "https://api.twitter.com/oauth/request_token";
 
@@ -163,7 +163,7 @@ namespace Twity
 
             if (request.isNetworkError)
             {
-                callback(false, request.error);
+                callback(false);
             }
             else
             {
@@ -179,20 +179,20 @@ namespace Twity
                     }
                     Oauth.requestToken = d["oauth_token"];
                     Oauth.requestTokenSecret = d["oauth_token_secret"];
-                    callback(true, "https://api.twitter.com/oauth/authorize?oauth_token=" + Oauth.requestToken);
+                    Oauth.authorizeURL = "https://api.twitter.com/oauth/authorize?oauth_token=" + Oauth.requestToken;
+                    callback(true);
                 }
                 else
                 {
-                    callback(false, request.downloadHandler.text);
+                    callback(false);
                 }
             }
         }
 
-        public static IEnumerator GenerateAccessToken(string pin, TwitterCallback callback)
+        public static IEnumerator GenerateAccessToken(string pin, TwitterAuthenticationCallback callback)
         {
             string url = "https://api.twitter.com/oauth/access_token";
 
-            Debug.Log(pin);
             SortedDictionary<string, string> p = new SortedDictionary<string, string>();
             p.Add("oauth_verifier", pin);
 
@@ -211,7 +211,7 @@ namespace Twity
 
             if (request.isNetworkError)
             {
-                callback(false, JsonHelper.ArrayToObject(request.error));
+                callback(false);
             }
             else
             {
@@ -228,12 +228,12 @@ namespace Twity
                     Oauth.accessToken = d["oauth_token"];
                     Oauth.accessTokenSecret = d["oauth_token_secret"];
                     
-                    callback(true, "success");
+                    callback(true);
                 }
                 else
                 {
                     Debug.Log(request.responseCode);
-                    callback(false, JsonHelper.ArrayToObject(request.downloadHandler.text));
+                    callback(false);
                 }
             }
         }
@@ -244,11 +244,11 @@ namespace Twity
 
         private static IEnumerator SendRequest(UnityWebRequest request, SortedDictionary<string, string> parameters, string method, string requestURL, TwitterCallback callback)
         {
-            if (Twity.Oauth.accessToken != null && Twity.Oauth.accessToken != "")
+            if (!string.IsNullOrEmpty(Oauth.accessToken))
             {
                 request.SetRequestHeader("Authorization", Oauth.GenerateHeaderWithAccessToken(parameters, method, requestURL));
             }
-            else if (Twity.Oauth.bearerToken != null && Twity.Oauth.bearerToken != "")
+            else if (!string.IsNullOrEmpty(Oauth.bearerToken))
             {
                 request.SetRequestHeader("Authorization", "Bearer " + Oauth.bearerToken);
             } 

--- a/Scripts/TwitterRequest.cs
+++ b/Scripts/TwitterRequest.cs
@@ -192,6 +192,7 @@ namespace Twity
         {
             string url = "https://api.twitter.com/oauth/access_token";
 
+            Debug.Log(pin);
             SortedDictionary<string, string> p = new SortedDictionary<string, string>();
             p.Add("oauth_verifier", pin);
 
@@ -216,7 +217,18 @@ namespace Twity
             {
                 if (request.responseCode == 200 || request.responseCode == 201)
                 {
-                    callback(true, JsonHelper.ArrayToObject(request.downloadHandler.text));
+                    string[] arr = request.downloadHandler.text.Split("&"[0]);
+                    Dictionary<string, string> d = new Dictionary<string, string>();
+                    foreach(string s in arr)
+                    {
+                        string k = s.Split("="[0])[0];
+                        string v = s.Split("="[0])[1];
+                        d[k] = v;
+                    }
+                    Oauth.accessToken = d["oauth_token"];
+                    Oauth.accessTokenSecret = d["oauth_token_secret"];
+                    
+                    callback(true, "success");
                 }
                 else
                 {

--- a/Scripts/TwitterRequest.cs
+++ b/Scripts/TwitterRequest.cs
@@ -186,7 +186,44 @@ namespace Twity
                     callback(false, request.downloadHandler.text);
                 }
             }
+        }
+
+        public static IEnumerator GenerateAccessToken(string pin, TwitterCallback callback)
+        {
+            string url = "https://api.twitter.com/oauth/access_token";
+
+            SortedDictionary<string, string> p = new SortedDictionary<string, string>();
+            p.Add("oauth_verifier", pin);
+
+            WWWForm form = new WWWForm();
+            form.AddField("oauth_verifier", pin);
+
+            UnityWebRequest request = UnityWebRequest.Post(url, form);
+            request.SetRequestHeader("Authorization", Oauth.GenerateHeaderWithAccessToken(p, "POST", url));
             
+            #if UNITY_2017_1
+                    yield return request.Send();
+            #endif
+            #if UNITY_2017_2_OR_NEWER
+                    yield return request.SendWebRequest();
+            #endif
+
+            if (request.isNetworkError)
+            {
+                callback(false, JsonHelper.ArrayToObject(request.error));
+            }
+            else
+            {
+                if (request.responseCode == 200 || request.responseCode == 201)
+                {
+                    callback(true, JsonHelper.ArrayToObject(request.downloadHandler.text));
+                }
+                else
+                {
+                    Debug.Log(request.responseCode);
+                    callback(false, JsonHelper.ArrayToObject(request.downloadHandler.text));
+                }
+            }
         }
 
         #endregion

--- a/Scripts/TwitterRequest.cs
+++ b/Scripts/TwitterRequest.cs
@@ -144,10 +144,15 @@ namespace Twity
 
         public static IEnumerator GenerateRequestToken(TwitterAuthenticationCallback callback)
         {
+            yield return GenerateRequestToken(callback, "oob");
+        }
+
+        public static IEnumerator GenerateRequestToken(TwitterAuthenticationCallback callback, string callbackURL)
+        {
             string url = "https://api.twitter.com/oauth/request_token";
 
             SortedDictionary<string, string> p = new SortedDictionary<string, string>();
-            p.Add("oauth_callback", "oob");
+            p.Add("oauth_callback", callbackURL);
 
             WWWForm form = new WWWForm();
 


### PR DESCRIPTION
https://developer.twitter.com/en/docs/basics/authentication/overview/pin-based-oauth
```C#
public class EventHandler : MonoBehaviour {
  void Start () {
    Twity.Oauth.consumerKey         = "...";
    Twity.Oauth.consumerSecret    = "...";
    
    StartCoroutine(Twity.Client.GenerateRequestToken(RequestTokenCallback));
  }

  void RequestCallback(bool success) {
    if (!success) return;
    // When request successes, you can display `Twity.Oauth.authorizeURL` to user so that they may use a web browser to access Twitter.
  }
  
  void GenerateAccessToken(string pin) {
    // pin is numbers displayed on web browser when user complete authorization.
    StartCoroutine(Twity.Client.GenerateAccessToken(pin, AccessTokenCallback));
  }
  
  void AccessTokenCallback(bool success) {
    if (!success) return;
    // When success, authorization is completed. You can make request to other endpoint.
  }
}
```